### PR TITLE
Script tag parsing, issue #26

### DIFF
--- a/lib/html5/constants.js
+++ b/lib/html5/constants.js
@@ -4,6 +4,7 @@ HTML5.CONTENT_MODEL_FLAGS = [
 	'PCDATA',
 	'RCDATA',
 	'CDATA',
+	'SCRIPT_CDATA',
 	'PLAINTEXT'
 ];
 
@@ -1053,7 +1054,7 @@ HTML5.E = {
  		"Unexpected %(name). Expected table content."
 };
 
-HTML5.Models = {PCDATA: 0, RCDATA: 1, CDATA: 2};
+HTML5.Models = {PCDATA: 0, RCDATA: 1, CDATA: 2, SCRIPT_CDATA: 3};
 
 HTML5.PHASES = PHASES = {
 	initial: require('./parser/initial_phase').Phase, 

--- a/lib/html5/parser.js
+++ b/lib/html5/parser.js
@@ -97,10 +97,17 @@ Parser.prototype.do_token = function(token) {
 		this.phase[method](token.data);
 		break;
 	case 'StartTag':
+		if (token.name == "script") {
+			this.inScript = true;
+			this.scriptBuffer = '';
+		}
 		this.phase[method](token.name, token.data, token.self_closing);
 		break;
 	case 'EndTag':
 		this.phase[method](token.name);
+		if (token.name == "script") {
+			this.inScript = false;
+		}
 		break;
 	case 'Doctype':
 		this.phase[method](token.name, token.publicId, token.systemId, token.correct);
@@ -138,8 +145,10 @@ Parser.prototype.setup = function(container, encoding) {
 		case 'textarea':
 			this.tokenizer.content_model = HTML5.Models.RCDATA;
 			break;
-		case 'style':
 		case 'script':
+			this.tokenizer.content_model = HTML5.Models.SCRIPT_CDATA;
+			break;
+		case 'style':
 		case 'xmp':
 		case 'iframe':
 		case 'noembed':

--- a/lib/html5/parser/in_head_phase.js
+++ b/lib/html5/parser/in_head_phase.js
@@ -103,7 +103,7 @@ p.prototype.startTagScript = function(name, attributes) {
 		this.tree.open_elements.last().appendChild(element);
 	}
 	this.tree.open_elements.push(element);
-	this.parser.tokenizer.content_model = HTML5.Models.CDATA;
+	this.parser.tokenizer.content_model = HTML5.Models.SCRIPT_CDATA;
 }
 
 p.prototype.startTagBaseLinkMeta = function(name, attributes) {

--- a/lib/html5/tokenizer.js
+++ b/lib/html5/tokenizer.js
@@ -81,7 +81,11 @@ t.prototype.tokenize = function() {
 t.prototype.emitToken = function(tok) { 
 	tok = this.normalize_token(tok);
 	HTML5.debug('tokenizer.token', tok)
-	this.emit('token', tok);
+	if (this.content_model == Models.SCRIPT_CDATA && tok.type == 'Characters') {
+		this.script_buffer += tok.data;
+	} else {
+		this.emit('token', tok);
+	}
 }
 
 t.prototype.consume_entity = function(buffer, from_attr) {
@@ -211,10 +215,16 @@ t.prototype.process_solidus_in_tag = function(buffer) {
 
 t.prototype.data_state = function(buffer) {
 	var c = buffer.char()
-	if(c != HTML5.EOF && this.content_model == Models.CDATA || this.content_model == Models.RCDATA) {
+	if(c != HTML5.EOF && this.content_model == Models.CDATA || this.content_model == Models.RCDATA || this.content_model == Models.SCRIPT_CDATA) {
 		this.lastFourChars += c;
 		if(this.lastFourChars.length >= 4) {
 			this.lastFourChars = this.lastFourChars.substr(-4)
+		}
+	}
+
+	if (this.content_model == Models.SCRIPT_CDATA) {
+		if (this.script_buffer == null) {
+			this.script_buffer = '';
 		}
 	}
 
@@ -224,13 +234,13 @@ t.prototype.data_state = function(buffer) {
 		return false;
 	} else if(c == '&' && (this.content_model == Models.PCDATA || this.content_model == Models.RCDATA) && !this.escapeFlag) {
 		this.state = 'entity_data_state';
-	} else if(c == '-' && (this.content_model == Models.CDATA || this.content_model == Models.RCDATA) && !this.escapeFlag && this.lastFourChars == '<!--') {
+	} else if(c == '-' && (this.content_model == Models.CDATA || this.content_model == Models.RCDATA || this.content_model == Models.SCRIPT_CDATA) && !this.escapeFlag && this.lastFourChars == '<!--') {
 		this.escapeFlag = true;
 		this.emitToken({type: 'Characters', data: c});
 		this.commit();
-	} else if(c == '<' && !this.escapeFlag && (this.content_model == Models.PCDATA || this.content_model == Models.RCDATA || this.content_model == Models.CDATA)) {
+	} else if(c == '<' && !this.escapeFlag && (this.content_model == Models.PCDATA || this.content_model == Models.RCDATA || this.content_model == Models.CDATA || this.content_model == Models.SCRIPT_CDATA)) {
 		this.state = 'tag_open_state';
-	} else if(c == '>' && this.escapeFlag && (this.content_model == Models.CDATA || this.content_model == Models.RCDATA) && this.lastFourChars.match(/-->$/)) {
+	} else if(c == '>' && this.escapeFlag && (this.content_model == Models.CDATA || this.content_model == Models.RCDATA || this.content_model == Models.SCRIPT_CDATA) && this.lastFourChars.match(/-->$/)) {
 		this.escapeFlag = false;
 		this.emitToken({type: 'Characters', data: c});
 		this.commit();
@@ -288,7 +298,7 @@ t.prototype.tag_open_state = function(buffer) {
 			this.state = 'data_state';
 		}
 	} else {
-		// We know the content model flag is set to either RCDATA or CDATA
+		// We know the content model flag is set to either RCDATA or CDATA or SCRIPT_CDATA
 		// now because this state can never be entered with the PLAINTEXT
 		// flag.
 		if (data == '/') {
@@ -303,7 +313,7 @@ t.prototype.tag_open_state = function(buffer) {
 }
 
 t.prototype.close_tag_open_state = function(buffer) {
-	if(this.content_model == Models.RCDATA || this.content_model == Models.CDATA) {
+	if(this.content_model == Models.RCDATA || this.content_model == Models.CDATA || this.content_model == Models.SCRIPT_CDATA) {
 		var chars = '';
 		if(this.current_token) {
 			for(var i = 0; i <= this.current_token.name.length; i++) {
@@ -810,6 +820,10 @@ t.prototype.emit_current_token = function() {
 			this.parse_error('self-closing-end-tag');
 		}
 		break;
+	}
+	if (this.current_token.name == "script") {
+		this.emitToken({ type: 'Characters', data: this.script_buffer });
+		this.script_buffer = null;
 	}
 	this.emitToken(tok);
 	this.state = 'data_state';


### PR DESCRIPTION
In reference to our discussion earlier, here's a patch in the HTML5 parser that delays emitting the Script tag until it's complete. Didn't seem like JSDom had much control over the tag emission in this case.

It needs some tests, but please let me know if you think it's going in the wrong direction. Good news is, it seems to solve my issue with Zombie.
