### PR TITLE
When buffering script data, also buffer when SpaceCharacters are encountered.

### DIFF
--- a/lib/html5/tokenizer.js
+++ b/lib/html5/tokenizer.js
@@ -81,7 +81,7 @@ t.prototype.tokenize = function() {
 t.prototype.emitToken = function(tok) { 
 	tok = this.normalize_token(tok);
 	HTML5.debug('tokenizer.token', tok)
-	if (this.content_model == Models.SCRIPT_CDATA && tok.type == 'Characters') {
+	if (this.content_model == Models.SCRIPT_CDATA && (tok.type == 'Characters' || tok.type == 'SpaceCharacters')) {
 		this.script_buffer += tok.data;
 	} else {
 		this.emit('token', tok);


### PR DESCRIPTION
While getting HTML5 to work with JSDOM, I noticed that sometimes script text wasn't being inserted all at once.  It would only happen if I had white space immediately following the <script> tag.  If I had other characters right after, things worked as expected.  I believe I've tracked the issue down to the fix in this pull request; it at least fixes the problem for me.
