### PR TITLE
Fix undefined reference to PHASES

### DIFF
--- a/lib/html5/parser/in_body_phase.js
+++ b/lib/html5/parser/in_body_phase.js
@@ -238,7 +238,7 @@ p.prototype.processCharacters = function(data) {
 }
 
 p.prototype.startTagProcessInHead = function(name, attributes) {
-	new PHASES.inHead(this.parser, this.tree).processStartTag(name, attributes);
+	new HTML5.PHASES.inHead(this.parser, this.tree).processStartTag(name, attributes);
 }
 
 p.prototype.startTagBody = function(name, attributes) {


### PR DESCRIPTION
It looks like part of the code was accidentally relying on PHASES being global.

`npm test`:
Before commit: 2143/2625
After commit: 2227/2675
