### PR TITLE
Preserve original attribute order in normalize_token

### DIFF
--- a/lib/html5/tokenizer.js
+++ b/lib/html5/tokenizer.js
@@ -861,13 +861,15 @@ var t = HTML5.Tokenizer = function HTML5Tokenizer(input, document) {
 			token.name = token.name.toLowerCase();
 			if(token.data.length != 0) {
 				var data = {};
+				// the first value for each key wins
 				token.data.reverse();
 				token.data.forEach(function(e) {
 					data[e.nodeName.toLowerCase()] = e.nodeValue;
 				});
 				token.data = [];
 				for(var k in data) {
-					token.data.push({nodeName: k, nodeValue: data[k]});
+					// unshift so that the original attribute order is restored
+					token.data.unshift({nodeName: k, nodeValue: data[k]});
 				}
 			}
 		} else if(token.type == 'EndTag') {


### PR DESCRIPTION
The order of attributes was reversed in normalize_token, and not restored to the original order. This patch swaps the final push to unshift, so that the order is restored. Round-tripping valid HTML should now produce (close to) identical HTML, which is important in applications where the HTML output is compared.

The number of passing tests is unchanged by this patch at 2227/2675.
