### PR TITLE
Use push/reverse instead of unshift

### DIFF
--- a/lib/html5/tokenizer.js
+++ b/lib/html5/tokenizer.js
@@ -868,9 +868,10 @@ var t = HTML5.Tokenizer = function HTML5Tokenizer(input, document) {
 				});
 				token.data = [];
 				for(var k in data) {
-					// unshift so that the original attribute order is restored
-					token.data.unshift({nodeName: k, nodeValue: data[k]});
+					token.data.push({nodeName: k, nodeValue: data[k]});
 				}
+				// restore original attribute order
+				token.data.reverse();
 			}
 		} else if(token.type == 'EndTag') {
 			if(token.data.length != 0) parse_error('attributes-in-end-tag');


### PR DESCRIPTION
According to http://jsperf.com/array-push-vs-unshift the combination of push
and reverse is more efficient than unshift even at small array sizes.
