### PR TITLE
Add var keyword to fix global leak.

### DIFF
--- a/lib/html5/debug.js
+++ b/lib/html5/debug.js
@@ -24,7 +24,7 @@ HTML5.disableDebug = function(section) {
 
 HTML5.dumpTagStack = function(tags) {
 	var r = [];
-	for(i in tags) {
+	for(var i in tags) {
 		r.push(tags[i].tagName);
 	}
 	return r.join(', ');

--- a/lib/html5/parser/in_body_phase.js
+++ b/lib/html5/parser/in_body_phase.js
@@ -650,6 +650,8 @@ p.prototype.endTagListItem = function(name) {
 
 p.prototype.endTagHeading = function(name) {
 	var error = true;
+	var i;
+
 	for(i in HTML5.HEADING_ELEMENTS) {
 		var el = HTML5.HEADING_ELEMENTS[i];
 		if(this.inScope(el)) {


### PR DESCRIPTION
It seems that global leaks still remain since many of them has been fixed.
