### PR TITLE
more var keywords, and two variable name errors

### DIFF
--- a/lib/html5/parser/in_body_phase.js
+++ b/lib/html5/parser/in_body_phase.js
@@ -493,7 +493,7 @@ p.prototype.endTagBr = function(name) {
 }
 
 p.prototype.startTagOptionOptgroup = function(name, attributes) {
-	if(this.inScope('option')) endTagOther('option');
+	if(this.inScope('option')) this.endTagOther('option');
 	this.tree.reconstructActiveFormattingElements();
 	this.tree.insert_element(name, attributes);
 }

--- a/lib/html5/serializer.js
+++ b/lib/html5/serializer.js
@@ -24,6 +24,7 @@ var default_opts = {
 }
 
 HTML5.serialize = function(src, target, override) {
+	var options;
 	if(!override) {
 		options = default_opts
 	} else {
@@ -84,7 +85,7 @@ HTML5.serialize = function(src, target, override) {
 			attrs = attrs.sort();
 			for(var ki in attrs) {
 				var quote_attr = false;
-				v = tok.data.getNamedItem(attrs[ki].nodeName).nodeValue;
+				var v = tok.data.getNamedItem(attrs[ki].nodeName).nodeValue;
 				attributes += " "+attrs[ki].nodeName;
 				if(!options.minimize_boolean_attributes || ((HTML5.BOOLEAN_ATTRIBUTES[tok.name] || []).indexOf(ki) == -1 && (HTML5.BOOLEAN_ATTRIBUTES["_global"].indexOf(ki) == -1))) {
 					attributes += "=";

--- a/lib/html5/tokenizer.js
+++ b/lib/html5/tokenizer.js
@@ -227,7 +227,7 @@ var t = HTML5.Tokenizer = function HTML5Tokenizer(input, document) {
 			var radix = 10;
 		}
 
-		chars = '';
+		var chars = '';
 
 		var c = buffer.char();
 		while(c !== HTML5.EOF && allowed.test(c)) {
@@ -243,7 +243,7 @@ var t = HTML5.Tokenizer = function HTML5Tokenizer(input, document) {
 			charAsInt = replacement;
 		}
 
-		char = String.fromCharCode(charAsInt);
+		var char = String.fromCharCode(charAsInt);
 		/*if(charAsInt <= 0x10FFFF && !(charAsInt >= 0xD800 && charAsInt <= 0xDFFF)) {
 		} else {
 			char = String.fromCharCode(0xFFFD);
@@ -382,7 +382,7 @@ var t = HTML5.Tokenizer = function HTML5Tokenizer(input, document) {
 			if(c !== HTML5.EOF) {
 				current_token.name += data + c
 			} else {
-				current_token_name += data
+				current_token.name += data
 				buffer.unget(c)
 				newState(data_state);
 			}

--- a/lib/html5/treewalker.js
+++ b/lib/html5/treewalker.js
@@ -19,6 +19,7 @@ function end_tag(node) {
 }
 
 function text(data, target) {
+	var m;
 	if(m = new RegExp("^[" + HTML5.SPACE_CHARACTERS + "]+").exec(data)) {
 		target.emit('token', {type: 'SpaceCharacters', data: m[0]});
 		data = data.slice(m[0].length, data.length);

--- a/tools/test-viewer/app.js
+++ b/tools/test-viewer/app.js
@@ -43,7 +43,7 @@ var base = '../../testdata/tree-construction/'
 var l = fs.readdirSync(base);
 var tests = []
 var HTML5 = require('../../lib/html5')
-serialize = require('../../tests/support/serializeTestOutput').serializeTestOutput;
+var serialize = require('../../tests/support/serializeTestOutput').serializeTestOutput;
 for(var t in l) {
 	var testname = l[t];
 	if(testname.match(/\.js$/)) continue;


### PR DESCRIPTION
Here are a few more var keywords, as well as two presumed variable name errors:

In `lib/html5/parser/in_body_phase.js`, line 496, I think it wants "this.endTagOther" and not "endTagOther".

In `lib/html5/tokenizer.js`  line 385, I think it wants "current_token.name" and not "current_token_name".

It looks like we don't have test coverage for those two, but before/after produce the same test result counts (891 tests pass, 447 tests fail).

p.s. I'm adding these because the Mocha test framework by default complains about global variable leaks, which makes my tests fail if I link html5.  I'm using jshint to find the vars.  Using this config for jshint:

```
jshint.conf:
{
    "asi": true,
    "undef": true
}
```

and this shell invocation:

```
jshint --config jshint.conf . | grep "is not defined" | grep -v require | grep -v console | grep -v exports | grep -v process | grep -v __dirname | grep -v module | grep -v assert | grep -v 'doc/'
```
