### PR TITLE
document.appendChild breaks in .create_structure_elements

### DIFF
--- a/lib/html5/treebuilder.js
+++ b/lib/html5/treebuilder.js
@@ -267,7 +267,8 @@ b.prototype.create_structure_elements = function(container) {
 	this.html_pointer = this.document.getElementsByTagName('html')[0]
 	if(!this.html_pointer) {
 		this.html_pointer = this.createElement('html');
-		this.document.documentElement.appendChild(this.html_pointer);
+
+		(this.document.documentElement||this.document).appendChild(this.html_pointer);
 	}
 	if(container == 'html') return;
 	if(!this.head_pointer) {


### PR DESCRIPTION
when an html element is not found in the document and document.appendChild is called.

``` sh
...node_modules/jsdom/lib/jsdom/level1/core.js:1361
      throw new core.DOMException(HIERARCHY_REQUEST_ERR);
            ^
Error: Hierarchy request error
    at Object.core.Document.appendChild (...node_modules/jsdom/lib/jsdom/level1/core.js:1361:13)
    at TreeBuilder.b.create_structure_elements (...node_modules/html5/lib/html5/treebuilder.js:275:17)
    at EventEmitter.Parser.setup (...node_modules/html5/lib/html5/parser.js:160:13)
    at EventEmitter.Parser.parse_fragment (...node_modules/html5/lib/html5/parser.js:56:8)
    at HtmlToDom.appendHtmlToElement (...node_modules/jsdom/lib/jsdom/browser/htmltodom.js:95:13)

```

this should certainly not be merged without tests. can you tell me what you would like to see?
i could be wrong but based on the spec HIERARCHY_REQUEST_ERR is correct in this case. 
