### PR TITLE
Removal of EOF debugging setter/getter

### DIFF
--- a/lib/html5/buffer.js
+++ b/lib/html5/buffer.js
@@ -5,12 +5,6 @@ function Buffer() {
 	this.data = '';
 	this.start = 0;
 	this.committed = 0;
-	var eof;
-	this.__defineSetter__('eof', function(f) {
-		eof = f
-		HTML5.debug('buffer.eof=', f)
-	})
-	this.__defineGetter__('eof', function() { return eof })
 	this.eof = false;
 }
 


### PR DESCRIPTION
Setter and getter calls are expensive and the eof property is commonly called. This should very slightly improve performance.
