### PR TITLE
Define 'assert' in this module, since it's used here.

### DIFF
--- a/lib/html5/parser.js
+++ b/lib/html5/parser.js
@@ -1,5 +1,6 @@
 var HTML5 = exports.HTML5 = require('../html5');
 
+var assert = require('assert');
 var events = require('events');
 
 require('./treebuilder');


### PR DESCRIPTION
Some earlier commits moved a bunch of code from other modules into parser.js, including references to assert.ok(), but assert was not in scope in parser.js. Make it so that it is.
