### PR TITLE
Add events.EventEmitter.call(this); to tokenizer

### DIFF
--- a/lib/html5/tokenizer.js
+++ b/lib/html5/tokenizer.js
@@ -16,6 +16,7 @@ function keys(h) {
 var ENTITY_KEYS = keys(HTML5.ENTITIES);
 
 var Tokenizer = HTML5.Tokenizer = function HTML5Tokenizer(input, document, tree) {
+	events.EventEmitter.call(this);
 	var state;
 	var buffer = new Buffer();
 	var escapeFlag = false;


### PR DESCRIPTION
We are using the tokenizer separetely and ran into problem instantiating it.   This patch fixes that :)
