### PR TITLE
Only use jsdom private apis when available.

### DIFF
--- a/lib/html5/treebuilder.js
+++ b/lib/html5/treebuilder.js
@@ -37,8 +37,12 @@ b.prototype.copyAttributeToElement = function(element, attribute) {
 b.prototype.createElement = function (name, attributes, namespace) {
 	var el;
     try {
-        el = (this.document._elementBuilders[name.toLowerCase()] || this.document._defaultElementBuilder)(this.document, name);
-        el._created = true;
+        if ( this.document._elementBuilders && this.document._defaultElementBuilder ) {
+          el = (this.document._elementBuilders[name.toLowerCase()] || this.document._defaultElementBuilder)(this.document, name);
+          el._created = true;
+        } else {
+          el = this.document.createElement( name );
+        }
     } catch(e) {
         console.log("Can't create element '"+ name + "' (" + e + ") Using a div for now. FIXME!")
 		el = this.document.createElement('div');


### PR DESCRIPTION
Introduced in fe7d2a784d6c649c35ea74f0c82282467c882997.

This reduces the likelihood of supporting other dom implementations.

See #76, #87.
