### PR TITLE
Attributes no longer inherit from Node in DOM4.

### DIFF
--- a/data/tree-construction/tests10.dat-22/result.tree
+++ b/data/tree-construction/tests10.dat-22/result.tree
@@ -4,4 +4,4 @@
   <body>
     xlink:href="foo"
     <svg svg>
-      xlink href="foo"
+      xlink:href="foo"

--- a/data/tree-construction/tests10.dat-23/result.tree
+++ b/data/tree-construction/tests10.dat-23/result.tree
@@ -6,5 +6,5 @@
     xml:lang="en"
     <svg svg>
       <svg g>
-        xlink href="foo"
-        xml lang="en"
+        xlink:href="foo"
+        xml:lang="en"

--- a/data/tree-construction/tests10.dat-24/result.tree
+++ b/data/tree-construction/tests10.dat-24/result.tree
@@ -6,5 +6,5 @@
     xml:lang="en"
     <svg svg>
       <svg g>
-        xlink href="foo"
-        xml lang="en"
+        xlink:href="foo"
+        xml:lang="en"

--- a/data/tree-construction/tests10.dat-25/result.tree
+++ b/data/tree-construction/tests10.dat-25/result.tree
@@ -6,6 +6,6 @@
     xml:lang="en"
     <svg svg>
       <svg g>
-        xlink href="foo"
-        xml lang="en"
+        xlink:href="foo"
+        xml:lang="en"
       "bar"

--- a/data/tree-construction/tests9.dat-23/result.tree
+++ b/data/tree-construction/tests9.dat-23/result.tree
@@ -4,4 +4,4 @@
   <body>
     xlink:href="foo"
     <math math>
-      xlink href="foo"
+      xlink:href="foo"

--- a/data/tree-construction/tests9.dat-24/result.tree
+++ b/data/tree-construction/tests9.dat-24/result.tree
@@ -6,5 +6,5 @@
     xml:lang="en"
     <math math>
       <math mi>
-        xlink href="foo"
-        xml lang="en"
+        xlink:href="foo"
+        xml:lang="en"

--- a/data/tree-construction/tests9.dat-25/result.tree
+++ b/data/tree-construction/tests9.dat-25/result.tree
@@ -6,5 +6,5 @@
     xml:lang="en"
     <math math>
       <math mi>
-        xlink href="foo"
-        xml lang="en"
+        xlink:href="foo"
+        xml:lang="en"

--- a/data/tree-construction/tests9.dat-26/result.tree
+++ b/data/tree-construction/tests9.dat-26/result.tree
@@ -6,6 +6,6 @@
     xml:lang="en"
     <math math>
       <math mi>
-        xlink href="foo"
-        xml lang="en"
+        xlink:href="foo"
+        xml:lang="en"
       "bar"

--- a/lib/html5/treebuilder.js
+++ b/lib/html5/treebuilder.js
@@ -12,24 +12,45 @@ b.prototype.reset = function() {
 	this.activeFormattingElements = [];
 }
 
+// from http://www.w3.org/TR/2011/WD-html5-20110405/namespaces.html
+var NAMESPACE_URI = {
+	html: "http://www.w3.org/1999/xhtml",
+	math: "http://www.w3.org/1998/Math/MathML",
+	svg: "http://www.w3.org/2000/svg",
+	xlink: "http://www.w3.org/1999/xlink",
+	xml: "http://www.w3.org/XML/1998/namespace",
+	xmlns: "http://www.w3.org/2000/xmlns/"
+}
+
 b.prototype.copyAttributeToElement = function(element, attribute) {
 	if(attribute.nodeType && attribute.nodeType == attribute.ATTRIBUTE_NODE) {
 		element.setAttributeNode(attribute.cloneNode());
-	} else {
-        try {
-			var id = '_HTML5ParserTempNode';
-			element.setAttribute(id, attribute.nodeValue);
-			var attr = element.getAttributeNode(id).cloneNode();
-			element.removeAttribute(id);
-
-			attr._nodeName = attr._tagName = attr._name = attribute.nodeName;
-			element.setAttributeNode(attr);
-        } catch(e) {
-            console.log("Can't set attribute '" + attribute.nodeName + "' to value '" + attribute.nodeValue + "': (" + e + ')', e.stack);
-        }
 		if(attribute.namespace) {
 			var at = element.getAttributeNode(attribute.nodeName);
 			at.namespace = attribute.namespace;
+		}
+	} else {
+		var name, value, namespace;
+		try {
+			if (attribute.nodeName) {
+				name = attribute.nodeName;
+				value = attribute.nodeValue;
+				if (attribute.namespace) {
+					name = attribute.namespace + ":" + name;
+					namespace = NAMESPACE_URI[ attribute.namespace ];
+				}
+			} else {
+				name = attribute.name;
+				value = attribute.value;
+				namespace = attribute.namespaceURI;
+			}
+			if (namespace) {
+				element.setAttributeNS(namespace, name, value);
+			} else {
+				element.setAttribute(name, value);
+			}
+		} catch(e) {
+			HTML5.debug("Can't set attribute '" + name + "' to value '" + value + "': (" + e + ')', e.stack);
 		}
 	}
 }

--- a/test/lib/serializeTestOutput.js
+++ b/test/lib/serializeTestOutput.js
@@ -24,7 +24,7 @@ exports.serializeTestOutput = function(doc) {
 				if( a1.nodeName == a2.nodeName) return 0;
 			});
 			for(var i = 0; i < a.length; i++) {
-				s += indent + (a[i].namespace ? a[i].namespace + ' ' : '') + a[i].nodeName + '="' + a[i].nodeValue + '"\n'
+				s += indent + (a[i].namespace ? a[i].namespace + ':' : '') + a[i].nodeName + '="' + a[i].nodeValue + '"\n'
 			}
 			break;
 		case 'EmptyTag':
@@ -39,7 +39,7 @@ exports.serializeTestOutput = function(doc) {
 				if( a1.nodeName == a2.nodeName) return 0;
 			});
 			for(var i = 0; i < a.length; i++) {
-				s += indent + '  ' + (a[i].namespace ? a[i].namespace + ' ' : '') + a[i].nodeName + '="' + a[i].nodeValue + '"\n'
+				s += indent + '  ' + (a[i].namespace ? a[i].namespace + ':' : '') + a[i].nodeName + '="' + a[i].nodeValue + '"\n'
 			}
 			break;
 		case 'EndTag':


### PR DESCRIPTION
For setAttributeNS(), namespaceURIs are mapped.

A few test outputs are altered to reflect that namespaces are no longer
tacked on a as property but are returned as part of the attribute value.
