### PR TITLE
Make jsdom an optional dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,11 @@
     }
   ],
   "dependencies": {
-    "jsdom": ">= 0.8.0",
     "opts": "~1.2.1",
     "html5-entities": "~0.5.0"
+  },
+  "optionalDependencies": {
+    "jsdom": ">= 0.8.0"
   },
   "devDependencies": {
     "tape": "~1.0.4",


### PR DESCRIPTION
Other doms (notably domino) are supported now and jsdom has a native dependency that some environments fail to build. As long as a document is set on the parser, jsdom isn't required so something like this works,

```
new HTML5.Parser({
    document: domino.createDocument( '<html></html>' )
});
```

https://github.com/wikimedia/mediawiki-extensions-Parsoid/blob/master/js/lib/mediawiki.HTML5TreeBuilder.node.js#L31-L33

See #69 as well.
