### PR TITLE
Made repository information conform with package.json standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,11 @@
     "url": "http://dinhe.net/~aredridel/"
   },
   "url": "http://dinhe.net/~aredridel/projects/js/html5/",
-  "repository": [
+  "repository": 
     {
       "type": "git",
-      "url": "git://github.com/aredridel/html5.git"
-    },
-    {
-      "type": "git",
-      "url": "http://theinternetco.net/~aredridel/projects/js/html5.git"
+      "url": "https://github.com/aredridel/html5"
     }
-  ],
   "contributors": [
     {
       "name": "Aria Stewart",


### PR DESCRIPTION
The repository element in package.json does not support an array of repositories. The implication of leaving the repository as an array means that the repository link is invalid in tools such as license-checker and is not displayed in npm (see picture).

![not displayed in npm](https://f.cloud.github.com/assets/1271036/1185874/ea26de30-22ce-11e3-9c92-c209725e9b26.png)
