### PR TITLE
Use a better algorithm for keeping track of the recognition of named entities

### DIFF
--- a/lib/html5/tokenizer.js
+++ b/lib/html5/tokenizer.js
@@ -5,7 +5,12 @@ var util = require('util');
 var Buffer = require('./buffer').Buffer;
 var Models = HTML5.Models;
 
-var ENTITY_KEYS = Object.keys(HTML5.ENTITIES);
+var namedEntityPrefixes = {};
+Object.keys(HTML5.ENTITIES).forEach(function (entityKey) {
+	for (var i = 0 ; i < entityKey.length ; i += 1) {
+		namedEntityPrefixes[entityKey.substr(0, i)] = true;
+	}
+});
 
 var Tokenizer = HTML5.Tokenizer = function HTML5Tokenizer(input, document, tree) {
 	events.EventEmitter.call(this);
@@ -89,16 +94,10 @@ var Tokenizer = HTML5.Tokenizer = function HTML5Tokenizer(input, document, tree)
 				parse_error("expected-numeric-entity");
 			}
 		} else {
-			var filteredEntityList = ENTITY_KEYS.filter(function(e) {
-				return e[0] == chars[0];
-			});
 			var entityName = null;
-			var matches = function(e) {
-				return e.indexOf(chars) === 0;
-			};
+
 			while(true) {
-				if (filteredEntityList.some(matches)) {
-					filteredEntityList = filteredEntityList.filter(matches);
+				if (namedEntityPrefixes[chars]) {
 					c = buffer.char();
 					if (c !== HTML5.EOF) {
 						chars += c;


### PR DESCRIPTION
I ran into a serious performance problem when parsing a 5 MB document that contained a lot of invalid named entities due to unencoded ampersands. Switching to a lookup table-based algorithm made my test case run in 8 seconds instead of 140 seconds.
