### PR TITLE
Replaced `IllegalArgumentException` with `Error`

### DIFF
--- a/lib/sax/TreeParser.js
+++ b/lib/sax/TreeParser.js
@@ -30,7 +30,7 @@ function TreeParser(contentHandler, lexicalHandler){
 	this.locatorDelegate;
 
 	if (!contentHandler) {
-		throw new IllegalArgumentException("contentHandler was null.");
+		throw new Error("contentHandler was null.");
 	}
 	this.contentHandler = contentHandler;
 	if (!lexicalHandler) {


### PR DESCRIPTION
There is no `IllegalArgumentException` in JS, and I doubt a `ReferenceError` is expected here.

I encountered this while trying to get [andreasmadsen/htmlparser-benchmark](https://github.com/andreasmadsen/htmlparser-benchmark) running with the latest html5 version. Do you have any suggestions for running this module with a minimal configuration?
